### PR TITLE
Start examples using command line and args

### DIFF
--- a/examples_server.py
+++ b/examples_server.py
@@ -1,0 +1,28 @@
+#! /usr/bin/env python3
+# -*- coding: utf-8 -*-
+
+import sys
+import os
+
+sys.path.insert(0, os.getcwd())
+
+if len(sys.argv) == 1 or sys.argv[1] == "example":
+    print("Standard example server")
+    from examples import s_app_cp
+
+    s_app_cp.run()
+elif sys.argv[1] == "remote_control":
+    print("Remote control example server")
+    from example_remote_control import s_comms_cp
+
+    s_comms_cp.run()
+elif sys.argv[1] == "qos":
+    print("QoS example server")
+    from qos import s_qos_cp
+
+    s_qos_cp.run()
+else:
+    print("Only these options are available:")
+    print("example")
+    print("remote_control")
+    print("qos")


### PR DESCRIPTION
This is a workaround to start the example servers from command line using this file.
You can give args about what to start: example (or no arg), remote_control, qos

~~Might need renaming of server modules as you removed the "_cp".~~ You only renamed the library, not the examples so should be fine.