### PR TITLE
Server no overhead independent reader

### DIFF
--- a/server.py
+++ b/server.py
@@ -85,7 +85,8 @@ async def _read(loop, conns, verbose, sock):
                             # assume that the Connection instance does not get removed before the sock does
                     else:
                         verbose and print('Got connection from client', client_id)
-                        conns[client_id] = Connection(loop, client_id, sock, verbose)
+                        client = Connection(loop, client_id, sock, verbose)
+                        conns[client_id] = client
                 if len(l) > 1:  # Have at least 1 newline
                     client.lines.extend(l[:-1])
                     buf = bytearray(l[-1].encode('utf8'))
@@ -182,7 +183,6 @@ class Connection:
         self.lock = Lock()
         loop.create_task(self._keepalive())
         self.lines = []
-        loop.create_task(self._read())
 
     def status(self):
         return self.sock is not None


### PR DESCRIPTION
This is a better approach than the last pull request I created. Works quite well in my testing environment.

Changes are: No more splitting _readid() and Connection._read(). Every new socket gets a _reader() coro that reads that socket. The first message is always the client_id. Once it receives the client_id it either creates a new Connection object or resumes the existing Connection object for this client_id by replacing the sock object (if the socket was closed). 
This way there is no overhead for new connections as they don't create a class instance, only coro. The Connection instance is independent of this _reader() coro.

I'm just trying to help. Maybe this implementation fixes the bug you encountered without losing functionality or introducing new possible problems. 